### PR TITLE
CRC Check Disable patch

### DIFF
--- a/Assemblies/README.txt
+++ b/Assemblies/README.txt
@@ -3,3 +3,4 @@ Copy the following from MFGClient_Data/Managed here:
 Assembly-CSharp.dll
 UniTask.dll
 VirtualSurround.dll
+Unity.ResourceManager.dll

--- a/MFGTweaks/MFGTweaks.csproj
+++ b/MFGTweaks/MFGTweaks.csproj
@@ -37,5 +37,8 @@
 		<Reference Include="..\Assemblies\VirtualSurround.dll" Publicize="true">
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="..\Assemblies\Unity.ResourceManager.dll" Publicize="true">
+			<Private>false</Private>
+		</Reference>
     </ItemGroup>
 </Project>

--- a/MFGTweaks/Tweaks/DisableCrc.cs
+++ b/MFGTweaks/Tweaks/DisableCrc.cs
@@ -1,0 +1,30 @@
+using HarmonyLib;
+using UnityEngine.ResourceManagement.ResourceProviders;
+
+namespace MFGTweaks.Tweaks;
+
+public class DisableCRC : BaseTweak
+{
+    public override string Description => "Disables CRC checks for Addressable Asset Bundles";
+
+    public override void Initialize()
+    {
+        Harmony.PatchAll(typeof(DisableCRC));
+    }
+    
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AssetBundleRequestOptions), "Crc", MethodType.Getter)]
+    private static bool Prefix_GetCrc(ref uint __result)
+    {
+        __result = 0u;
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AssetBundleRequestOptions), "UseCrcForCachedBundle", MethodType.Getter)]
+    private static bool Prefix_GetUseCrcForCachedBundle(ref bool __result)
+    {
+        __result = false;
+        return false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Includes various QoL improvements:
 - **EnableHeadphoneOptions**: Force enables the option in the ingame menu to change the headphone volume
 - **ExtraNetcafeVoices**: Makes the girls say special NetCafe specific voice lines on touch. Only Iyo and girls released after her have them
 - **MuteBGM**: Lets you mute in-game BGM using Alt + M
+- **DisableCRC**: Allows you to modify the Addressable AssetBundles found in StreamingAssets/aa/StandaloneWindows64
 
 ## MFGTileNumbers
 


### PR DESCRIPTION
allows modification of the Addressable Asset Bundles found in MFGClient_Data/StreamingAssets/aa/StandaloneWindows64/, this is a very simple patch and needs an extra dll file (Unity.ResourceManager.dll) in the Assemblies folder